### PR TITLE
Generate pdf receipt from excel data

### DIFF
--- a/Narije.Infrastructure/Repositories/ReciptsRepository.cs
+++ b/Narije.Infrastructure/Repositories/ReciptsRepository.cs
@@ -250,16 +250,19 @@ namespace Narije.Infrastructure.Repositories
         #region ExportPdfRecipt
         public async Task<FileContentResult> ExportPdfRecipt(int? customerId, DateTime date)
         {
-            // Set QuestPDF license to avoid validation exception
-            QuestPDF.Settings.License = LicenseType.Community;
-
             using var transaction = await _NarijeDBContext.Database.BeginTransactionAsync();
 
             string pdfPath = null;
+            string tempXlsxPath = null;
             Recipt recipt = null;
             try
             {
-                // Fetch customer (optional)
+                ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+                string templatePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/templates/ReciptTemplate.xlsx");
+                using var package = new ExcelPackage(new FileInfo(templatePath));
+                var ws = package.Workbook.Worksheets[0];
+
                 Customer customer = null;
                 string parentTitle = null;
                 if (customerId.HasValue)
@@ -273,11 +276,18 @@ namespace Narije.Infrastructure.Repositories
                             .FirstOrDefaultAsync();
                     }
                 }
+
                 var customerFullTitle = (customer == null)
                     ? string.Empty
                     : (string.IsNullOrWhiteSpace(parentTitle) ? customer.Title : $"{customer.Title} - {parentTitle}");
 
-                // Use the same data as Excel for identical content
+                ws.Cells["B2"].Value = customerFullTitle;
+                ws.Cells["D2"].Value = customer?.DeliverFullName ?? string.Empty;
+                ws.Cells["G2"].Value = customer?.Address ?? string.Empty;
+                ws.Cells["B3"].Value = customer?.Code ?? string.Empty;
+                ws.Cells["D3"].Value = customer?.DeliverPhoneNumber ?? string.Empty;
+                ws.Cells["G3"].Value = date.ToString("yyyy/MM/dd");
+
                 var reserveQuery = _NarijeDBContext.vReserves
                     .Where(r => r.DateTime.Date == date.Date && r.Num > 0 && r.State != (int)EnumReserveState.perdict);
                 if (customerId.HasValue)
@@ -302,7 +312,52 @@ namespace Narije.Infrastructure.Repositories
                     .OrderBy(x => x.FoodTitle)
                     .ToList();
 
-                // Create Recipt record for PDF
+                int startRow = 6;
+                int templateRowCount = 6;
+                int nextSectionRow = 12;
+
+                if (reserves.Count > templateRowCount)
+                {
+                    int extraRows = reserves.Count - templateRowCount;
+                    ws.InsertRow(nextSectionRow, extraRows);
+
+                    int styleA = ws.Cells[11, 1].StyleID;
+                    int styleB = ws.Cells[11, 2].StyleID;
+                    int styleC = ws.Cells[11, 3].StyleID;
+                    int styleD = ws.Cells[11, 4].StyleID;
+                    int styleE = ws.Cells[11, 5].StyleID;
+                    int styleF = ws.Cells[11, 6].StyleID;
+                    int styleG = ws.Cells[11, 7].StyleID;
+                    double rowHeight = ws.Row(11).Height;
+
+                    for (int r = nextSectionRow; r < nextSectionRow + extraRows; r++)
+                    {
+                        ws.Row(r).Height = rowHeight;
+                        ws.Cells[r, 1].StyleID = styleA;
+                        ws.Cells[r, 2].StyleID = styleB;
+                        ws.Cells[r, 3].StyleID = styleC;
+                        ws.Cells[r, 4].StyleID = styleD;
+                        ws.Cells[r, 5].StyleID = styleE;
+                        ws.Cells[r, 6].StyleID = styleF;
+                        ws.Cells[r, 7].StyleID = styleG;
+
+                        ws.Cells[r, 3, r, 4].Merge = true;
+                        ws.Cells[r, 6, r, 7].Merge = true;
+                    }
+                }
+
+                int row = startRow;
+
+                foreach (var item in reserves)
+                {
+                    ws.Cells[row, 1].Value = row - startRow + 1;
+                    ws.Cells[row, 2].Value = item.FoodCode;
+                    ws.Cells[row, 3].Value = item.FoodTitle;
+                    ws.Cells[row, 5].Value = item.Quantity;
+                    ws.Cells[row, 6].Value = string.Empty;
+                    row++;
+                }
+
                 var identity = _IHttpContextAccessor.HttpContext.User.Identity as ClaimsIdentity;
                 if ((identity is null) || (identity.Claims.Count() == 0))
                     throw new Exception("دسترسی ندارید");
@@ -330,84 +385,49 @@ namespace Narije.Infrastructure.Repositories
                 _NarijeDBContext.Recipt.Update(recipt);
                 await _NarijeDBContext.SaveChangesAsync();
 
-                // Build PDF using QuestPDF with the same header and table columns
-                var pdfBytes = Document.Create(document =>
-                {
-                    document.Page(page =>
-                    {
-                        page.Size(PageSizes.A4);
-                        page.Margin(20);
-                        page.DefaultTextStyle(x => x.FontSize(10));
+                ws.Cells["G1"].Value = $"کد سند: {recipt.FileName}";
 
-                        page.Content().Column(col =>
-                        {
-                            col.Spacing(8);
-                            col.Item().AlignCenter().Text("رسید تحویل محصول").FontSize(16).SemiBold();
-                            col.Item().Row(r =>
-                            {
-                                r.RelativeItem().Text(text => { text.Span("کد سند: "); text.Span(recipt.FileName); });
-                            });
-                            col.Item().Row(r =>
-                            {
-                                r.RelativeItem().Text(text => { text.Span("نام مشتری: "); text.Span(customerFullTitle); });
-                                r.RelativeItem().Text(text => { text.Span("کد مشتری: "); text.Span(customer?.Code ?? string.Empty); });
-                            });
-                            col.Item().Row(r =>
-                            {
-                                r.RelativeItem().Text(text => { text.Span("نام تحویل گیرنده: "); text.Span(customer?.DeliverFullName ?? string.Empty); });
-                                r.RelativeItem().Text(text => { text.Span("شماره تماس تحویل گیرنده: "); text.Span(customer?.DeliverPhoneNumber ?? string.Empty); });
-                            });
-                            col.Item().Row(r =>
-                            {
-                                r.RelativeItem().Text(text => { text.Span("آدرس: "); text.Span(customer?.Address ?? string.Empty); });
-                                r.RelativeItem().Text(text => { text.Span("تاریخ: "); text.Span(date.ToString("yyyy/MM/dd")); });
-                            });
-
-                            col.Item().Text("مشخصات موادغذایی ارسالی").SemiBold();
-                            col.Item().Table(table =>
-                            {
-                                table.ColumnsDefinition(columns =>
-                                {
-                                    columns.RelativeColumn(1);   // ردیف
-                                    columns.RelativeColumn(2);   // کد کالا
-                                    columns.RelativeColumn(4);   // نام کالا
-                                    columns.RelativeColumn(2);   // مقدار/تعداد
-                                    columns.RelativeColumn(4);   // توضیحات
-                                });
-
-                                table.Header(header =>
-                                {
-                                    header.Cell().Text("ردیف").SemiBold();
-                                    header.Cell().Text("کد کالا").SemiBold();
-                                    header.Cell().Text("نام کالا").SemiBold();
-                                    header.Cell().Text("مقدار/ تعداد").SemiBold();
-                                    header.Cell().Text("توضیحات").SemiBold();
-                                });
-
-                                int index = 1;
-                                foreach (var item in reserves)
-                                {
-                                    table.Cell().Text(index.ToString());
-                                    table.Cell().Text(item.FoodCode);
-                                    table.Cell().Text(item.FoodTitle);
-                                    table.Cell().Text(item.Quantity.ToString());
-                                    table.Cell().Text("");
-                                    index++;
-                                }
-                            });
-                        });
-                    });
-                }).GeneratePdf();
-
-                // Persist physical file under /data/recipts
                 var basePath = "/data/recipts";
                 if (!Directory.Exists(basePath))
                     Directory.CreateDirectory(basePath);
+                tempXlsxPath = Path.Combine(basePath, $"{recipt.FileName}.xlsx");
+                await File.WriteAllBytesAsync(tempXlsxPath, package.GetAsByteArray());
+
+                // Convert XLSX to PDF using headless LibreOffice (so the visual output matches Excel template)
+                var tempOutputDir = Path.GetDirectoryName(tempXlsxPath);
+                var libreOfficePathCandidates = new[] { "/usr/bin/soffice", "/usr/lib/libreoffice/program/soffice" };
+                var sofficePath = libreOfficePathCandidates.FirstOrDefault(File.Exists);
+                if (string.IsNullOrEmpty(sofficePath))
+                    throw new Exception("LibreOffice (soffice) is not installed in the runtime environment.");
+
+                var process = new System.Diagnostics.Process();
+                process.StartInfo.FileName = sofficePath;
+                process.StartInfo.Arguments = $"--headless --nologo --convert-to pdf --outdir \"{tempOutputDir}\" \"{tempXlsxPath}\"";
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.CreateNoWindow = true;
+                process.Start();
+                string stdOut = await process.StandardOutput.ReadToEndAsync();
+                string stdErr = await process.StandardError.ReadToEndAsync();
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    throw new Exception($"LibreOffice conversion failed. ExitCode={process.ExitCode}. Error={stdErr}. Output={stdOut}");
+                }
+
                 pdfPath = Path.Combine(basePath, $"{recipt.FileName}.pdf");
-                await File.WriteAllBytesAsync(pdfPath, pdfBytes);
+                if (!File.Exists(pdfPath))
+                {
+                    throw new Exception("Expected PDF not found after conversion.");
+                }
+
+                // Remove temporary xlsx file. We only keep PDF as the persisted artifact
+                try { if (File.Exists(tempXlsxPath)) File.Delete(tempXlsxPath); } catch { }
 
                 await transaction.CommitAsync();
 
+                var pdfBytes = await File.ReadAllBytesAsync(pdfPath);
                 return new FileContentResult(pdfBytes, "application/pdf")
                 {
                     FileDownloadName = $"{recipt.FileName}.pdf"
@@ -420,6 +440,11 @@ namespace Narije.Infrastructure.Repositories
                 if (!string.IsNullOrWhiteSpace(pdfPath) && File.Exists(pdfPath))
                 {
                     try { File.Delete(pdfPath); } catch { }
+                }
+
+                if (!string.IsNullOrWhiteSpace(tempXlsxPath) && File.Exists(tempXlsxPath))
+                {
+                    try { File.Delete(tempXlsxPath); } catch { }
                 }
 
                 throw;

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -22,6 +22,26 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 
+# Install LibreOffice (headless) and common fonts for proper Persian rendering
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       libreoffice \
+       fonts-dejavu \
+       fonts-dejavu-core \
+       fonts-dejavu-extra \
+       fonts-liberation \
+       fonts-noto \
+       fonts-noto-cjk \
+       fonts-noto-mono \
+       fonts-noto-color-emoji \
+       fonts-noto-unhinted \
+       fonts-noto-ui-core \
+       fonts-noto-ui-extra \
+       fonts-noto-extra \
+       fonts-freefont-ttf \
+       ttf-mscorefonts-installer || true \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN ln -s /data/ /app/images
 
 ENTRYPOINT ["dotnet", "Narije.Api.dll"]

--- a/main.Dockerfile
+++ b/main.Dockerfile
@@ -22,6 +22,26 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 
+# Install LibreOffice (headless) and common fonts for proper Persian rendering
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       libreoffice \
+       fonts-dejavu \
+       fonts-dejavu-core \
+       fonts-dejavu-extra \
+       fonts-liberation \
+       fonts-noto \
+       fonts-noto-cjk \
+       fonts-noto-mono \
+       fonts-noto-color-emoji \
+       fonts-noto-unhinted \
+       fonts-noto-ui-core \
+       fonts-noto-ui-extra \
+       fonts-noto-extra \
+       fonts-freefont-ttf \
+       ttf-mscorefonts-installer || true \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN ln -s /data/ /app/images
 
 ENTRYPOINT ["dotnet", "Narije.Api.dll"]


### PR DESCRIPTION
Refactor `ExportPdfRecipt` to generate PDFs by converting the Excel template via LibreOffice, ensuring identical visual output to XLSX.

The previous PDF generation used QuestPDF, which produced a different layout than the Excel-based export. This change ensures the PDF output precisely matches the Excel template by first generating the Excel file and then converting it to PDF using headless LibreOffice. Dockerfiles are updated to include LibreOffice and fonts for proper rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-c05d8275-e22e-4903-bf47-22668bd66ddb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c05d8275-e22e-4903-bf47-22668bd66ddb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

