### PR TITLE
Generate pdf receipt from excel data

### DIFF
--- a/Narije.Infrastructure/Repositories/ReciptsRepository.cs
+++ b/Narije.Infrastructure/Repositories/ReciptsRepository.cs
@@ -20,6 +20,7 @@ using OfficeOpenXml;
 using OfficeOpenXml.Style;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
@@ -250,16 +251,20 @@ namespace Narije.Infrastructure.Repositories
         #region ExportPdfRecipt
         public async Task<FileContentResult> ExportPdfRecipt(int? customerId, DateTime date)
         {
-            // Set QuestPDF license to avoid validation exception
-            QuestPDF.Settings.License = LicenseType.Community;
+            ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
 
             using var transaction = await _NarijeDBContext.Database.BeginTransactionAsync();
 
+            string xlsxTempPath = null;
             string pdfPath = null;
             Recipt recipt = null;
             try
             {
-                // Fetch customer (optional)
+                // Step 1: Generate Excel file using the same logic as ExportRecipt
+                string templatePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/templates/ReciptTemplate.xlsx");
+                using var package = new ExcelPackage(new FileInfo(templatePath));
+                var ws = package.Workbook.Worksheets[0];
+
                 Customer customer = null;
                 string parentTitle = null;
                 if (customerId.HasValue)
@@ -273,11 +278,18 @@ namespace Narije.Infrastructure.Repositories
                             .FirstOrDefaultAsync();
                     }
                 }
+
                 var customerFullTitle = (customer == null)
                     ? string.Empty
                     : (string.IsNullOrWhiteSpace(parentTitle) ? customer.Title : $"{customer.Title} - {parentTitle}");
 
-                // Use the same data as Excel for identical content
+                ws.Cells["B2"].Value = customerFullTitle;                          // نام مشتری
+                ws.Cells["D2"].Value = customer?.DeliverFullName ?? string.Empty;   // نام تحویل گیرنده
+                ws.Cells["G2"].Value = customer?.Address ?? string.Empty;           // آدرس
+                ws.Cells["B3"].Value = customer?.Code ?? string.Empty;              // کد مشتری
+                ws.Cells["D3"].Value = customer?.DeliverPhoneNumber ?? string.Empty;// شماره تماس تحویل گیرنده
+                ws.Cells["G3"].Value = date.ToString("yyyy/MM/dd");               // تاریخ
+
                 var reserveQuery = _NarijeDBContext.vReserves
                     .Where(r => r.DateTime.Date == date.Date && r.Num > 0 && r.State != (int)EnumReserveState.perdict);
                 if (customerId.HasValue)
@@ -302,7 +314,52 @@ namespace Narije.Infrastructure.Repositories
                     .OrderBy(x => x.FoodTitle)
                     .ToList();
 
-                // Create Recipt record for PDF
+                int startRow = 6;
+                int templateRowCount = 6;
+                int nextSectionRow = 12;
+
+                if (reserves.Count > templateRowCount)
+                {
+                    int extraRows = reserves.Count - templateRowCount;
+                    ws.InsertRow(nextSectionRow, extraRows);
+
+                    int styleA = ws.Cells[11, 1].StyleID;
+                    int styleB = ws.Cells[11, 2].StyleID;
+                    int styleC = ws.Cells[11, 3].StyleID;
+                    int styleD = ws.Cells[11, 4].StyleID;
+                    int styleE = ws.Cells[11, 5].StyleID;
+                    int styleF = ws.Cells[11, 6].StyleID;
+                    int styleG = ws.Cells[11, 7].StyleID;
+                    double rowHeight = ws.Row(11).Height;
+
+                    for (int r = nextSectionRow; r < nextSectionRow + extraRows; r++)
+                    {
+                        ws.Row(r).Height = rowHeight;
+                        ws.Cells[r, 1].StyleID = styleA;
+                        ws.Cells[r, 2].StyleID = styleB;
+                        ws.Cells[r, 3].StyleID = styleC;
+                        ws.Cells[r, 4].StyleID = styleD;
+                        ws.Cells[r, 5].StyleID = styleE;
+                        ws.Cells[r, 6].StyleID = styleF;
+                        ws.Cells[r, 7].StyleID = styleG;
+
+                        ws.Cells[r, 3, r, 4].Merge = true;
+                        ws.Cells[r, 6, r, 7].Merge = true;
+                    }
+                }
+
+                int row = startRow;
+
+                foreach (var item in reserves)
+                {
+                    ws.Cells[row, 1].Value = row - startRow + 1;      // ردیف
+                    ws.Cells[row, 2].Value = item.FoodCode;            // کد کالا
+                    ws.Cells[row, 3].Value = item.FoodTitle;           // نام کالا (C:D merged)
+                    ws.Cells[row, 5].Value = item.Quantity;            // مقدار/تعداد
+                    ws.Cells[row, 6].Value = string.Empty;             // توضیحات (F:G merged)
+                    row++;
+                }
+
                 var identity = _IHttpContextAccessor.HttpContext.User.Identity as ClaimsIdentity;
                 if ((identity is null) || (identity.Claims.Count() == 0))
                     throw new Exception("دسترسی ندارید");
@@ -319,7 +376,7 @@ namespace Narije.Infrastructure.Repositories
                     CustomerId = customerId,
                     CustomerParentId = customerParentId,
                     ReserveIds = string.Join(",", reserveIds),
-                    FileType = (int)EnumFileType.pdf,
+                    FileType = (int)EnumFileType.pdf,  // Save as PDF in database
                     FileName = string.Empty
                 };
 
@@ -330,83 +387,39 @@ namespace Narije.Infrastructure.Repositories
                 _NarijeDBContext.Recipt.Update(recipt);
                 await _NarijeDBContext.SaveChangesAsync();
 
-                // Build PDF using QuestPDF with the same header and table columns
-                var pdfBytes = Document.Create(document =>
-                {
-                    document.Page(page =>
-                    {
-                        page.Size(PageSizes.A4);
-                        page.Margin(20);
-                        page.DefaultTextStyle(x => x.FontSize(10));
+                ws.Cells["G1"].Value = $"کد سند: {recipt.FileName}";
 
-                        page.Content().Column(col =>
-                        {
-                            col.Spacing(8);
-                            col.Item().AlignCenter().Text("رسید تحویل محصول").FontSize(16).SemiBold();
-                            col.Item().Row(r =>
-                            {
-                                r.RelativeItem().Text(text => { text.Span("کد سند: "); text.Span(recipt.FileName); });
-                            });
-                            col.Item().Row(r =>
-                            {
-                                r.RelativeItem().Text(text => { text.Span("نام مشتری: "); text.Span(customerFullTitle); });
-                                r.RelativeItem().Text(text => { text.Span("کد مشتری: "); text.Span(customer?.Code ?? string.Empty); });
-                            });
-                            col.Item().Row(r =>
-                            {
-                                r.RelativeItem().Text(text => { text.Span("نام تحویل گیرنده: "); text.Span(customer?.DeliverFullName ?? string.Empty); });
-                                r.RelativeItem().Text(text => { text.Span("شماره تماس تحویل گیرنده: "); text.Span(customer?.DeliverPhoneNumber ?? string.Empty); });
-                            });
-                            col.Item().Row(r =>
-                            {
-                                r.RelativeItem().Text(text => { text.Span("آدرس: "); text.Span(customer?.Address ?? string.Empty); });
-                                r.RelativeItem().Text(text => { text.Span("تاریخ: "); text.Span(date.ToString("yyyy/MM/dd")); });
-                            });
+                // Step 2: Save Excel to temporary file
+                xlsxTempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.xlsx");
+                await package.SaveAsAsync(new FileInfo(xlsxTempPath));
 
-                            col.Item().Text("مشخصات موادغذایی ارسالی").SemiBold();
-                            col.Item().Table(table =>
-                            {
-                                table.ColumnsDefinition(columns =>
-                                {
-                                    columns.RelativeColumn(1);   // ردیف
-                                    columns.RelativeColumn(2);   // کد کالا
-                                    columns.RelativeColumn(4);   // نام کالا
-                                    columns.RelativeColumn(2);   // مقدار/تعداد
-                                    columns.RelativeColumn(4);   // توضیحات
-                                });
-
-                                table.Header(header =>
-                                {
-                                    header.Cell().Text("ردیف").SemiBold();
-                                    header.Cell().Text("کد کالا").SemiBold();
-                                    header.Cell().Text("نام کالا").SemiBold();
-                                    header.Cell().Text("مقدار/ تعداد").SemiBold();
-                                    header.Cell().Text("توضیحات").SemiBold();
-                                });
-
-                                int index = 1;
-                                foreach (var item in reserves)
-                                {
-                                    table.Cell().Text(index.ToString());
-                                    table.Cell().Text(item.FoodCode);
-                                    table.Cell().Text(item.FoodTitle);
-                                    table.Cell().Text(item.Quantity.ToString());
-                                    table.Cell().Text("");
-                                    index++;
-                                }
-                            });
-                        });
-                    });
-                }).GeneratePdf();
-
-                // Persist physical file under /data/recipts
+                // Step 3: Convert Excel to PDF
                 var basePath = "/data/recipts";
                 if (!Directory.Exists(basePath))
                     Directory.CreateDirectory(basePath);
                 pdfPath = Path.Combine(basePath, $"{recipt.FileName}.pdf");
-                await File.WriteAllBytesAsync(pdfPath, pdfBytes);
+
+                byte[] pdfBytes = null;
+                
+                // Try to convert using LibreOffice if available
+                if (await IsLibreOfficeAvailable())
+                {
+                    pdfBytes = await ConvertExcelToPdfWithLibreOffice(xlsxTempPath, pdfPath);
+                }
+                else
+                {
+                    // Fallback: Generate PDF that mimics Excel layout using QuestPDF
+                    pdfBytes = await GeneratePdfFromExcelData(package, recipt.FileName, customer, customerFullTitle, 
+                                                               date, reserves, pdfPath);
+                }
 
                 await transaction.CommitAsync();
+
+                // Clean up temporary Excel file
+                if (File.Exists(xlsxTempPath))
+                {
+                    try { File.Delete(xlsxTempPath); } catch { }
+                }
 
                 return new FileContentResult(pdfBytes, "application/pdf")
                 {
@@ -417,6 +430,11 @@ namespace Narije.Infrastructure.Repositories
             {
                 try { await transaction.RollbackAsync(); } catch { }
 
+                if (!string.IsNullOrWhiteSpace(xlsxTempPath) && File.Exists(xlsxTempPath))
+                {
+                    try { File.Delete(xlsxTempPath); } catch { }
+                }
+
                 if (!string.IsNullOrWhiteSpace(pdfPath) && File.Exists(pdfPath))
                 {
                     try { File.Delete(pdfPath); } catch { }
@@ -426,6 +444,196 @@ namespace Narije.Infrastructure.Repositories
             }
         }
 
+        private async Task<bool> IsLibreOfficeAvailable()
+        {
+            try
+            {
+                using var process = new System.Diagnostics.Process();
+                process.StartInfo.FileName = "libreoffice";
+                process.StartInfo.Arguments = "--version";
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.StartInfo.CreateNoWindow = true;
+                process.Start();
+                await process.WaitForExitAsync();
+                return process.ExitCode == 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private async Task<byte[]> ConvertExcelToPdfWithLibreOffice(string excelPath, string pdfPath)
+        {
+            var outputDir = Path.GetDirectoryName(pdfPath);
+            var tempPdfName = Path.GetFileNameWithoutExtension(excelPath) + ".pdf";
+            var tempPdfPath = Path.Combine(outputDir, tempPdfName);
+
+            using var process = new System.Diagnostics.Process();
+            process.StartInfo.FileName = "libreoffice";
+            process.StartInfo.Arguments = $"--headless --convert-to pdf --outdir \"{outputDir}\" \"{excelPath}\"";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.CreateNoWindow = true;
+            process.Start();
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode != 0)
+            {
+                var error = await process.StandardError.ReadToEndAsync();
+                throw new Exception($"LibreOffice conversion failed: {error}");
+            }
+
+            // Move the converted file to the desired location
+            if (File.Exists(tempPdfPath) && tempPdfPath != pdfPath)
+            {
+                File.Move(tempPdfPath, pdfPath, true);
+            }
+
+            return await File.ReadAllBytesAsync(pdfPath);
+        }
+
+        private async Task<byte[]> GeneratePdfFromExcelData(ExcelPackage package, string fileName, Customer customer, 
+                                                             string customerFullTitle, DateTime date, 
+                                                             dynamic reserves, string pdfPath)
+        {
+            // Set QuestPDF license
+            QuestPDF.Settings.License = LicenseType.Community;
+            
+            var ws = package.Workbook.Worksheets[0];
+            
+            // Generate PDF that closely mimics Excel layout
+            var pdfBytes = Document.Create(document =>
+            {
+                document.Page(page =>
+                {
+                    page.Size(PageSizes.A4);
+                    page.Margin(30);
+                    page.DefaultTextStyle(x => x.FontSize(11).FontFamily("Tahoma"));
+
+                    page.Content().Column(col =>
+                    {
+                        col.Spacing(10);
+                        
+                        // Header with document code
+                        col.Item().Row(r =>
+                        {
+                            r.RelativeItem().AlignCenter().Text("رسید تحویل محصول").FontSize(16).Bold();
+                            r.ConstantItem(150).AlignRight().Text($"کد سند: {fileName}").FontSize(10);
+                        });
+
+                        // Customer information table
+                        col.Item().PaddingTop(10).Border(1).BorderColor(Colors.Grey.Lighten2).Table(table =>
+                        {
+                            table.ColumnsDefinition(columns =>
+                            {
+                                columns.RelativeColumn(1.5f);  // Label
+                                columns.RelativeColumn(2);     // Value
+                                columns.RelativeColumn(1.5f);  // Label
+                                columns.RelativeColumn(2);     // Value
+                                columns.RelativeColumn(1.5f);  // Label
+                                columns.RelativeColumn(3);     // Value
+                            });
+
+                            // Row 1
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Background(Colors.Grey.Lighten4)
+                                  .Padding(5).Text("نام مشتری:").SemiBold();
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                  .Text(customerFullTitle);
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Background(Colors.Grey.Lighten4)
+                                  .Padding(5).Text("نام تحویل گیرنده:").SemiBold();
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                  .Text(customer?.DeliverFullName ?? string.Empty);
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Background(Colors.Grey.Lighten4)
+                                  .Padding(5).Text("آدرس:").SemiBold();
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                  .Text(customer?.Address ?? string.Empty);
+
+                            // Row 2
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Background(Colors.Grey.Lighten4)
+                                  .Padding(5).Text("کد مشتری:").SemiBold();
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                  .Text(customer?.Code ?? string.Empty);
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Background(Colors.Grey.Lighten4)
+                                  .Padding(5).Text("شماره تماس:").SemiBold();
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                  .Text(customer?.DeliverPhoneNumber ?? string.Empty);
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Background(Colors.Grey.Lighten4)
+                                  .Padding(5).Text("تاریخ:").SemiBold();
+                            table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                  .Text(date.ToString("yyyy/MM/dd"));
+                        });
+
+                        // Section title
+                        col.Item().PaddingTop(15).Text("مشخصات موادغذایی ارسالی").FontSize(12).SemiBold();
+
+                        // Items table
+                        col.Item().PaddingTop(5).Border(1).BorderColor(Colors.Grey.Lighten2).Table(table =>
+                        {
+                            table.ColumnsDefinition(columns =>
+                            {
+                                columns.ConstantColumn(40);   // ردیف
+                                columns.RelativeColumn(1.5f); // کد کالا
+                                columns.RelativeColumn(3);    // نام کالا
+                                columns.RelativeColumn(1.5f); // مقدار/تعداد
+                                columns.RelativeColumn(2.5f); // توضیحات
+                            });
+
+                            // Header
+                            table.Cell().Background(Colors.Grey.Lighten3).Border(0.5f).BorderColor(Colors.Grey.Lighten1)
+                                  .Padding(5).AlignCenter().Text("ردیف").SemiBold();
+                            table.Cell().Background(Colors.Grey.Lighten3).Border(0.5f).BorderColor(Colors.Grey.Lighten1)
+                                  .Padding(5).AlignCenter().Text("کد کالا").SemiBold();
+                            table.Cell().Background(Colors.Grey.Lighten3).Border(0.5f).BorderColor(Colors.Grey.Lighten1)
+                                  .Padding(5).AlignCenter().Text("نام کالا").SemiBold();
+                            table.Cell().Background(Colors.Grey.Lighten3).Border(0.5f).BorderColor(Colors.Grey.Lighten1)
+                                  .Padding(5).AlignCenter().Text("مقدار/تعداد").SemiBold();
+                            table.Cell().Background(Colors.Grey.Lighten3).Border(0.5f).BorderColor(Colors.Grey.Lighten1)
+                                  .Padding(5).AlignCenter().Text("توضیحات").SemiBold();
+
+                            // Data rows
+                            int index = 1;
+                            foreach (var item in reserves)
+                            {
+                                table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                      .AlignCenter().Text(index.ToString());
+                                table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                      .AlignCenter().Text(item.FoodCode);
+                                table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                      .Text(item.FoodTitle);
+                                table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                      .AlignCenter().Text(item.Quantity.ToString());
+                                table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                      .Text(string.Empty);
+                                index++;
+                            }
+
+                            // Add empty rows to match Excel template (minimum 6 rows)
+                            while (index <= 6)
+                            {
+                                table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                      .MinHeight(25).Text(string.Empty);
+                                table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                      .Text(string.Empty);
+                                table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                      .Text(string.Empty);
+                                table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                      .Text(string.Empty);
+                                table.Cell().Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(5)
+                                      .Text(string.Empty);
+                                index++;
+                            }
+                        });
+                    });
+                });
+            }).GeneratePdf();
+
+            await File.WriteAllBytesAsync(pdfPath, pdfBytes);
+            return pdfBytes;
+        }
 
         #endregion
     }

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,6 +4,12 @@ WORKDIR /app
 USER root
 EXPOSE 80
 
+# Install LibreOffice for Excel to PDF conversion
+RUN apt-get update && \
+    apt-get install -y libreoffice-calc fonts-liberation && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src

--- a/main.Dockerfile
+++ b/main.Dockerfile
@@ -4,6 +4,12 @@ WORKDIR /app
 USER root
 EXPOSE 80
 
+# Install LibreOffice for Excel to PDF conversion
+RUN apt-get update && \
+    apt-get install -y libreoffice-calc fonts-liberation && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src


### PR DESCRIPTION
Modify `ExportPdfRecipt` to generate PDF from an Excel template, ensuring the PDF output's UI is identical to the Excel report.

The `ExportPdfRecipt` method now first generates the Excel file, then attempts to convert it to PDF using LibreOffice for an exact layout match. A QuestPDF fallback is included to closely replicate the Excel structure if LibreOffice is unavailable. Dockerfiles are updated to include LibreOffice installation.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fe40142-2a6a-49c3-a526-9ef5f3ad30ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fe40142-2a6a-49c3-a526-9ef5f3ad30ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

