### PR TITLE
Generate multi-customer pdf receipts

### DIFF
--- a/Narije.Infrastructure/Repositories/ReciptsRepository.cs
+++ b/Narije.Infrastructure/Repositories/ReciptsRepository.cs
@@ -623,6 +623,10 @@ namespace Narije.Infrastructure.Repositories
                         int maxRow = ws.Dimension.End.Row;
                         var source = ws.Cells[1, 1, maxRow, 7];
                         var destination = wsResult.Cells[currentRow, 1];
+                        if (currentRow > 1)
+                        {
+                            wsResult.Row(currentRow).PageBreak = true;
+                        }
                         source.Copy(destination);
 
                         // Copy row heights and merges within A..G
@@ -690,13 +694,13 @@ namespace Narije.Infrastructure.Repositories
                 }
                 package.Workbook.Worksheets.Delete(wsTemplate);
 
-                // Configure print settings for A4 landscape and 80% scale on Result sheet
+                // Configure print settings for A4 portrait and fit-to-width on Result sheet
                 int lastRow = Math.Max(1, currentRow - 1);
                 wsResult.PrinterSettings.PaperSize = OfficeOpenXml.ePaperSize.A4;
                 wsResult.PrinterSettings.Orientation = OfficeOpenXml.eOrientation.Portrait;
                 wsResult.PrinterSettings.FitToPage = true;
                 wsResult.PrinterSettings.FitToWidth = 1;
-                wsResult.PrinterSettings.FitToHeight = 1;
+                wsResult.PrinterSettings.FitToHeight = 0;
                 wsResult.PrinterSettings.HorizontalCentered = true;
                 wsResult.PrinterSettings.LeftMargin = wsTemplate.PrinterSettings.LeftMargin;
                 wsResult.PrinterSettings.RightMargin = wsTemplate.PrinterSettings.RightMargin;


### PR DESCRIPTION
Add page breaks to the PDF receipt export to ensure each customer's data starts on a new page.

The previous PDF export combined all customer data onto a single Excel sheet and then forced it to fit on one PDF page. This update adds explicit page breaks in the Excel sheet before each new customer's data and configures the PDF print settings to allow for multiple pages, resolving the pagination issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-1288cda2-9933-4a33-8133-44e8dcefcada">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1288cda2-9933-4a33-8133-44e8dcefcada">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

